### PR TITLE
Use custom data field config if available

### DIFF
--- a/mu_interface/Edge_Device/edge_device.py
+++ b/mu_interface/Edge_Device/edge_device.py
@@ -9,10 +9,11 @@ from mu_interface.Utilities.data2csv import data2csv
 
 class Edge_Device():
 
-    def __init__(self, file_path):
+    def __init__(self, csv_path, cfg_path=None):
         self.sub = ZMQ_Subscriber()
-        self.file_path = file_path
+        self.csv_path = csv_path
         self.csv_objects = {}
+        self.cfg_path = cfg_path
         self.msg_counter = Counter()
         self.start_time = None
 
@@ -22,7 +23,7 @@ class Edge_Device():
         """
         self.start_time = datetime.datetime.now()
         logging.info("Started listening at %s.", self.start_time.strftime("%d.%m.%Y. %H:%M:%S"))
-        logging.info("Saving data to: %s", self.file_path)
+        logging.info("Saving data to: %s", self.csv_path)
         last_csv_time = datetime.datetime.now()
         last_info_time = datetime.datetime.now()
         
@@ -78,7 +79,7 @@ class Edge_Device():
                     file_name = f"{node}_{current_time.strftime('%Y_%m_%d-%H_%M_%S')}.csv"
                     file_path = self.csv_objects[node].file_path
                     additionalSensors = copy.deepcopy(self.csv_objects[node].additionalSensors)
-                    self.csv_objects[sender] = data2csv(file_path, file_name, additionalSensors)
+                    self.csv_objects[sender] = data2csv(file_path, file_name, additionalSensors, self.cfg_path)
                 last_csv_time = current_time
 
 
@@ -87,9 +88,11 @@ class Edge_Device():
         if sender not in self.csv_objects:
             file_name = f"{sender}_{datetime.datetime.now().strftime('%Y_%m_%d-%H_%M_%S')}.csv"
             if additionalSensors == "energy":
-                self.csv_objects[sender] = data2csv(self.file_path / sender / "energy", file_name, additionalSensors)
+                self.csv_objects[sender] = data2csv(self.csv_path / sender / "energy", 
+                                                    file_name, additionalSensors, self.cfg_path)
             else:
-                self.csv_objects[sender] = data2csv(self.file_path / sender[:-5] / sender[-4:], file_name, additionalSensors)
+                self.csv_objects[sender] = data2csv(self.csv_path / sender[:-5] / sender[-4:], 
+                                                    file_name, additionalSensors, self.cfg_path)
             logging.info("Created file: %s", file_name)
 
         # Read and format the data.

--- a/mu_interface/Edge_Device/main.py
+++ b/mu_interface/Edge_Device/main.py
@@ -8,13 +8,24 @@ from pathlib import Path
 from edge_device import Edge_Device
 from mu_interface.Utilities.log_formatter import setup_logger
 
-def main(csv_dir):
+def main(csv_dir, fields_cfg):
     setup_logger("rock")
     logging.info("Starting edge node.")
 
     csv_dir = Path(csv_dir)
+    
+    # If args.cfg is None, look for a file in the current directory
+    fields_cfg = None
+    if args.cfg is None:
+        custom_cfg = Path(sys.executable).parent.absolute() / 'custom_data_fields.yaml'
+        print(custom_cfg)
+        if custom_cfg.exists():
+            fields_cfg = custom_cfg
+    else:
+        fields_cfg = Path(args.cfg)
+            
 
-    ED = Edge_Device(csv_dir)
+    ED = Edge_Device(csv_dir, fields_cfg)
     while True:
         try:
             ED.start()
@@ -35,7 +46,8 @@ def main(csv_dir):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Arguments for the sensor node.")
     parser.add_argument('--dir', action='store', default=Path.home() / 'measurements')
+    parser.add_argument('--cfg', action='store', default=None)
     args = parser.parse_args()
-
-    main(args.dir)
+        
+    main(args.dir, args.cfg)
     


### PR DESCRIPTION
Data fields recorded in the Edge device script can now be set up by passing the file path as an argument to the main script, or by placing the file in the same folder as the packaged executable.